### PR TITLE
Fix CI conditions again

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -145,7 +145,7 @@ jobs:
         run: pnpm build
 
       - name: 📤 Upload artifact
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v2
         with:
           path: ./build


### PR DESCRIPTION
[WIP](https://stackoverflow.com/questions/76815509/jobs-getting-skipped-in-github-actions), needing to figure out why `deploy` and `perf-check` are skipped even on `push` event.