### PR TITLE
Fix compatibility with GH pages

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -182,13 +182,15 @@ jobs:
         run: pnpm i # no need for `--no-frozen-lockfile` here, as the sync is ensured by the `prechecks` job
 
       - name: 🔨 Build repo
-        run: pnpm build
+        run: |
+          pnpm build
+          touch build/.nojekyll
 
       - name: 📤 Upload artifact
         if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v2
         with:
-          path: ./build
+          path: build
 
   deploy:
     name: Deploy website to GitHub Pages


### PR DESCRIPTION
Fix/improve compatibility between SvelteKit and GitHub Pages, especially for error pages (with `+error.svelte`) that are not currently working. This works by removing any "GitHub magic sauce" by adding a `.nojekyll` file.

It could've been done by directly adding this empty file in the `/static` folder, however doing it through CI allows us to keep a platform-independent codebase and not get it polluted by yet another dot-file.

Both solutions come from [the official docs](https://kit.svelte.dev/docs/adapter-static#github-pages) for the `adapter-static` we're using.