### PR TITLE
Auto-release versions from CI

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           echo current_version=$(gh release view --json tagName | jq -r ".tagName" | sed "s/v//") >> $GITHUB_OUTPUT
           echo version=$(node -pe "require('./package.json').version") >> $GITHUB_OUTPUT
-          
+
           # Gather all commits since last release, excluding merge commits and commits from dependabot, formatted as markdown list of "- commit title - @commit-author"
           changelog=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty="- %s - @%an" --no-merges --invert-grep --grep="dependabot")
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,8 +20,34 @@ jobs:
           echo current_version=$(gh release view --json tagName | jq -r ".tagName" | sed "s/v//") >> $GITHUB_OUTPUT
           echo version=$(node -pe "require('./package.json').version") >> $GITHUB_OUTPUT
 
-          # Gather all commits since last release, excluding merge commits and commits from dependabot, formatted as markdown list of "- commit title - @commit-author"
-          changelog=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty="- %s - @%an" --no-merges --invert-grep --grep="dependabot")
+          # Get all changes & authors of commits since last release, excluding merge commits and commits from dependabot
+          IFS=$'\n' changes=($(git log $(git describe --tags --abbrev=0)..HEAD --pretty="%s" --no-merges --invert-grep --grep="dependabot"))
+          IFS=$'\n' authors=($(git log $(git describe --tags --abbrev=0)..HEAD --pretty="%ae" --no-merges --invert-grep --grep="dependabot"))
+
+          # Map author emails to GitHub usernames in a map
+          declare -A author_map
+          while read -r author; do
+            # if author ends with @users.noreply.github.com, parse the username between '+' and '@'
+            if [[ $author == *"@users.noreply.github.com" ]]; then
+              username=$(echo "$author" | cut -d'@' -f1 | cut -d'+' -f2)
+              author_map[$author]=$username
+              continue
+            fi
+            # otherwise, search for the author's GitHub username using the GitHub API
+            username=$(gh api search/users?q="$author"+in:email | jq -r ".items[0].login")
+            author_map[$author]=$username
+          done <<< "$(echo "${authors[*]}" | uniq)"
+
+          # Assemble changelog, by formatting it as "- <commit message> - @<author>", where author is picked from the index of the current change, and is passed through the author_map to get the GitHub username
+          changelog=()
+          for i in "${!changes[@]}"; do
+            author=${authors[$i]}
+            handle=${author_map[$author]}
+            changelog+=("- ${changes[$i]} - @$handle")
+          done
+
+          # Export the changelog as a string
+          echo changelog="${changelog[*]}" >> $GITHUB_OUTPUT
 
       - name: ✨ Create release
         if: steps.version-check.outputs.version != steps.version-check.outputs.current_version

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,36 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📁 Checkout
+        uses: actions/checkout@v4
+
+      - name: 📦 Get versions
+        id: version-check
+        run: |
+          echo current_version=$(gh release view --json tagName | jq -r ".tagName" | sed "s/v//") >> $GITHUB_OUTPUT
+          echo version=$(node -pe "require('./package.json').version") >> $GITHUB_OUTPUT
+          
+          # Gather all commits since last release, excluding merge commits and commits from dependabot, formatted as markdown list of "- commit title - @commit-author"
+          changelog=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty="- %s - @%an" --no-merges --invert-grep --grep="dependabot")
+
+      - name: ✨ Create release
+        if: steps.version-check.outputs.version != steps.version-check.outputs.current_version
+        uses: actions/create-release@v1
+        with:
+          tag_name: v${{ steps.version-check.outputs.version }}
+          release_name: ${{ steps.version-check.outputs.version }}
+          body: |
+            ## What's Changed
+            ${{ steps.version-check.outputs.changelog }}
+
+            **Full Changelog:** https://github.com/${{ github.repository }}/compare/v${{ steps.version-check.outputs.current_version }}...v${{ steps.version-check.outputs.version }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -46,6 +46,9 @@ jobs:
             changelog+=("- ${changes[$i]} - @$handle")
           done
 
+          # Print the changelog to the console
+          echo "Changelog: ${changelog[*]}"
+
           # Export the changelog as a string
           echo changelog="${changelog[*]}" >> $GITHUB_OUTPUT
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emerald-website",
-	"version": "1.0.0",
+	"version": "1.0.2",
 	"private": true,
 	"scripts": {
 		"dev": "vite",


### PR DESCRIPTION
Automate the release process by automatically pushing a new release with the appropriate content when the `version` field of `package.json` changes.

Also, bump the version in `package.json` because it was still `1.0.0` (this will trigger this new pipeline, but without creating a new release as it already exists)

### Example for this branch
Based on what the current releases already look like
```
## What's Changed
- Fix lint - @WarningImHack3r
- Initial CI file - @WarningImHack3r
- Change navbar height (#120) - @MinixBF
- Improve the process section on mobile (#116) - @MinixBF
- Phone contact in Contact page (#113) - @WarningImHack3r
- Initial release fixes (#112) - @WarningImHack3r

**Full Changelog:** https://github.com/EmeraldHQ/Website/compare/v1.0.2...v1.0.2
```

### Left to do
- [x] Bind committer names to GitHub handles