### PR TITLE
Fix prune not deleting local branches anymore

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -6,4 +6,5 @@ if [ "$3" == 1 ]; then  # branch checkout only (not file checkout)
     pnpm deps:install
     # remove local branches that have been deleted on remote
     git fetch -p
+    pnpx git-removed-branches -p -f
 fi


### PR DESCRIPTION
Rollbacks a change made on #94 that was my mistake: `git fetch -p` does _not_ replace `pnpx git-removed-branches -p`.

- `git fetch -p` only prunes **remote** branches that no longer exist
- `git-removed-branches -p` prunes **local** branches that no longer exist on remote

Adding this line back will do the trick perfectly, without any risk of desync, and the addition of `-f` prevents git from misleadingly saying that the branch is not fully merged, as advised by [the docs](https://github.com/nemisj/git-removed-branches#forcing-removal).