### PR TITLE
infra: Automate add of reviewers to pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @EmeraldHQ/developers


### PR DESCRIPTION
Automatically add reviewers to the open pull requests by using the [codeowners](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) feature of GitHub.

They should be added automatically to review once the PR is open _and_ **not** a draft, which should make one less click to do! Another advantage: it automatically asks for reviews in Dependabot/Renovate/external PRs!

I created the team so that we don't have to edit the file ever again, reviewers _are_ the members of the team. Also, I tweaked the repo's settings to enable mandatory reviews from code owners.