### PR TITLE
infra: Auto-release - Fix empty changes throwing an error

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,8 +32,8 @@ jobs:
           echo version=$(node -pe "require('./package.json').version") >> $GITHUB_OUTPUT
 
           # Get all changes & authors of commits since last release, excluding merge commits and commits from dependabot or renovate
-          IFS=$'\n' changes=($(git log $latest_tag..HEAD --pretty="%s" --no-merges --perl-regexp --author='^((?!dependabot\[bot\]|renovate).*)$'))
-          IFS=$'\n' authors=($(git log $latest_tag..HEAD --pretty="%ae" --no-merges --perl-regexp --author='^((?!dependabot\[bot\]|renovate).*)$'))
+          IFS=$'\n' changes=($(git log $latest_tag..HEAD --pretty="%s" --no-merges --perl-regexp --author='^((?!dependabot\[bot\]|renovate\[bot\]).*)$'))
+          IFS=$'\n' authors=($(git log $latest_tag..HEAD --pretty="%ae" --no-merges --perl-regexp --author='^((?!dependabot\[bot\]|renovate\[bot\]).*)$'))
 
           # If there are no changes, set changelog as "_No changes_" and exit
           if [ ${#changes[@]} -eq 0 ]; then

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -35,6 +35,13 @@ jobs:
           IFS=$'\n' changes=($(git log $latest_tag..HEAD --pretty="%s" --no-merges --perl-regexp --author='^((?!dependabot\[bot\]|renovate).*)$'))
           IFS=$'\n' authors=($(git log $latest_tag..HEAD --pretty="%ae" --no-merges --perl-regexp --author='^((?!dependabot\[bot\]|renovate).*)$'))
 
+          # If there are no changes, set changelog as "_No changes_" and exit
+          if [ ${#changes[@]} -eq 0 ]; then
+            echo "Changelog: No changes"
+            echo changelog="_No changes_" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Map author emails to GitHub usernames in a map
           declare -A author_map
           while read -r author; do


### PR DESCRIPTION
### What happened?
02c0f1113e2175e8d706f54bafa3ca8a708a1530 threw an error in the Auto-Release workflow: https://github.com/EmeraldHQ/Website/actions/runs/6584967728/job/17902950964.

After inspecting the weird log, I figured out where the error was thanks to the `print` statements I added in the previous fixes.

What's happening is that during the "committer email ➜ GitHub @" retrieving phase, it was iterating over an empty element for some reason. This mysterious element doesn't meet the `if` condition, so it's headed over to the `else` block and the GitHub API call, which throws the 422 error code.

### What's the problem?
But what is that empty element that's being iterated over? I first thought of a parsing error, but that made no sense. Then I realized that the only change from the latest release (`v1.0.3`) was the Dependabot merge which triggered this action. I got it: _the only author in that `authors` list is Dependabot_.

At that point, you might be wondering:
> "But Antoine, you already excluded Dependabot and Renovate from being included in that list in #155, how can that even be causing an issue?"

Good point, glad you asked. What's happening is some sort of bash weirdness: as the `authors` list is empty (cause the only author is Dependabot, which is excluded), the `while` loop _still loops over one empty item_ for some reason.  
The empty `$author` does not match the first `if` condition, falls back into the `else` block, then makes the API calls and you know the rest.

### The fix
We have 2 options to fix this:
- Try to not make the while loop run over that empty element
- Make a `if authors.length == 0` before all that

As the first option, if it works, would make us have to handle an empty `changelog` list as a result, the second option is the best (and most readable) choice. _(I also didn't find a simple, reliable, and working solution for the first option, so it's easier to make the second!)_

So I simply added the comment, let Copilot fill the gap, fixed its code and here we are!

> I really hope this is the last fix for auto-release, I want it to work and be rock solid for once!

---
### Edit
I just added the `[bot]` suffix to Renovate in author detection, just for aesthetic and parity. That's it!