### PR TITLE
Add <hr> tag to the Contact page

### DIFF
--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -233,6 +233,7 @@
 							<option class="bg-black/50" value="none">
 								{i("contact.fields.budget.none")}
 							</option>
+							<hr>
 							<option class="bg-black/50" value="less">
 								{i("contact.fields.budget.less")}
 							</option>


### PR DESCRIPTION
1-line PR, quick and easy: I just learned in [a Tweet](https://x.com/una/status/1716481290982048079) that **Chrome 119**, as well as **Safari 17**, now support `<hr>` tags into `<select>`s.

I instantly thought we could use it in the only place I've ever used a `<select>`: the Contact page.
It is not only a gimmick that I wanna use because I learned its existence: it _does_ make sense to separate "No budget" from the rest.

It also doesn't cost a thing: on an unsupported/outdated browser, it will just not work, so no issue on that side! It will naturally become available to up-to-date users, and older browsers won't make a difference before/after this PR.

### Result
So here we are, one line of change, 4 characters, here is the result:

<img src="https://github.com/EmeraldHQ/Website/assets/43064022/800714d1-09dc-4c00-8ab9-fdf4ade858ae" alt="Before" width="300" /> | <img src="https://github.com/EmeraldHQ/Website/assets/43064022/dc82a1f1-d65d-47e3-971e-02ee25da9a8c" alt="After" width="300" />
:---: | :---:
**Before** | **After**

> [!NOTE]
> Despite the support coming in Chrome 119, these screenshots come from Arc, which still uses Chromium 118, as 119 is still nightly. It seems to already be supported I don't know!