### PR TITLE
infra: Auto release - Escape HTML tags & better readability

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -69,8 +69,9 @@ jobs:
           # Print the changelog to the console
           echo "Changelog: ${changelog[*]}"
 
-          # Export the changelog as a string
-          echo "changelog<<EOF"$'\n'"${changelog[*]//\"/\\\"}"$'\n'EOF >> $GITHUB_OUTPUT
+          # Export the changelog as a string, escaping double quotes and < characters when they are followed by a letter
+          escaped_changelog=$(printf '%s\n' "${changelog[*]//\"/\\\"}" | sed -e 's/\(<[a-z]\)/\\\1/g')
+          echo "changelog<<EOF"$'\n'"${escaped_changelog}"$'\n'"EOF" >> $GITHUB_OUTPUT
 
       - name: ✨ Create release
         if: steps.version-check.outputs.version != steps.version-check.outputs.current_version


### PR DESCRIPTION
Last fix for auto release: escape HTML tags to prevent them from being interpreted by the GitHub Releases markdown.

> I really didn't get lucky: double quotes + HTML tags, I think every possible edge case has been met in those very 2 commits.
> **Good point**: now the workflow is rock solid and we will be able to use it fearlessly!