### PR TITLE
infra: Don't rename PRs if they're from Dependabot or Renovate

### DIFF
--- a/.github/workflows/pr-title-changer.yml
+++ b/.github/workflows/pr-title-changer.yml
@@ -14,6 +14,7 @@ jobs:
   pr-title-modifier:
     name: PR Title Modifier
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
Quick refinement PR: disable the PR Title Modifier workflow when the PR is from Dependabot or Renovate. This is for 4 reasons:
- Avoid doing a useless thing
- Avoid launching yet another workflow run on GH's servers
- Don't mix actual `infra:` PRs from us with simple dependencies updates PRs
- Avoid a (funny) robot war:
   <img src="https://github.com/EmeraldHQ/Website/assets/43064022/72a05336-19ca-4edc-9e11-14fa23cdc1fa" alt="Robot war" width="500" />