### PR TITLE
infra: Renovate - Fix config & add validation workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
 	"packageRules": [
 		{
 			"matchManagers": ["github-actions", "npm"],
-			"matchDepNames": ["!/^@inlang/"],
+			"excludePackagePatterns": ["^@inlang"],
 			"groupName": "{{manager}}",
 			"addLabels": ["{{manager}}"]
 		},

--- a/.github/workflows/renovate-validator.yml
+++ b/.github/workflows/renovate-validator.yml
@@ -1,0 +1,23 @@
+name: Renovate Config Validation
+
+on:
+  pull_request:
+    paths:
+      - .github/renovate.json
+
+jobs:
+  renovate-config-validation:
+    name: Renovate Config Validator
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📁 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🧭 Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: ✅ Validate Renovate Config
+        run: |
+          bun i -g renovate
+          renovate-config-validator


### PR DESCRIPTION
## Fix configuration
Renovate has not worked since #153: it never opened an npm updates PR. This is likely due to the `matchDepNames` line because it's the only one different from [Mintstone](https://github.com/WarningImHack3r/Mintstone), where it's working fine.
Additionally, `matchDepNames` didn't make sense as a key, because it's a pattern we're using, not a list of names. This change now makes more sense and is used in [a few repos](https://grep.app/search?q=excludePackagePatterns&filter[lang][0]=JSON&filter[lang][1]=JSON5).

## Validation workflow
On another hand, I think it's a shame we don't have _any_ feedback on whether the current configuration is valid or not, except for the (not useful) Mend dashboard.
Dependabot has one by default out-of-the-box, so it's a kind of regression not to have it with Renovate too.

While browsing the docs for the configuration issue, I stumbled upon the [Config Validator](https://docs.renovatebot.com/config-validation/) page, which is exactly what we need.
As a result, I created a workflow for that purpose, only when the config is modified, and of course, sped up by Bun.