### PR TITLE
infra: Fix Renovate still not opening PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:base", ":disableDependencyDashboard"],
-	"labels": ["dependency"],
+	"extends": ["config:recommended", ":disableDependencyDashboard"],
+	"labels": ["dependencies"],
 	"rangeStrategy": "bump",
 	"packageRules": [
 		{

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:base", ":disableDependencyDashboard"],
 	"labels": ["dependencies"],
+	"rangeStrategy": "bump",
 	"packageRules": [
 		{
 			"matchManagers": ["github-actions", "npm"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:base", ":disableDependencyDashboard"],
-	"labels": ["dependencies"],
+	"labels": ["dependency"],
 	"rangeStrategy": "bump",
 	"packageRules": [
 		{


### PR DESCRIPTION
Renovate _still doesn't_ open PRs, despite it finding new updates... It randomly doesn't support `pnpm-lock.yaml` anymore:
<img src="https://github.com/EmeraldHQ/Website/assets/43064022/cdb6a7e2-63cb-4ae4-910b-d04a04bfd32c" alt="Issue log" width="350" />

After Googling the problem, I found [this recent GitHub discussion](https://github.com/renovatebot/renovate/discussions/22133) where the solution (despite having no sense) was to set the [`rangeStrategy`](https://docs.renovatebot.com/configuration-options/#rangestrategy) key in the configuration.
`"pin"` is not something we want, so I'm using `"bump"` instead.

I don't know how a config key that doesn't (seem to) impact the _lock_ file would resolve the issue, but let's try it out!

Additionally, the Renovate Config Validator workflow I made suggested upgrading from `config:base` to [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended), so I'm including that too.

### Update
Just tested this exact config on my private replica repo and it worked like a charm!