### PR TITLE
infra: Fix Prettier 3 not working with plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"mini-svg-data-uri": "^1.4.4",
 		"postcss": "^8.4.31",
 		"postcss-import": "^15.1.0",
-		"prettier": "^3.0.3",
+		"prettier": "^3.1.0",
 		"prettier-plugin-svelte": "^3.0.3",
 		"prettier-plugin-tailwindcss": "^0.5.6",
 		"svelte": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,14 +60,14 @@ devDependencies:
     specifier: ^15.1.0
     version: 15.1.0(postcss@8.4.31)
   prettier:
-    specifier: ^3.0.3
-    version: 3.0.3
+    specifier: ^3.1.0
+    version: 3.1.0
   prettier-plugin-svelte:
     specifier: ^3.0.3
-    version: 3.0.3(prettier@3.0.3)(svelte@4.2.2)
+    version: 3.0.3(prettier@3.1.0)(svelte@4.2.2)
   prettier-plugin-tailwindcss:
     specifier: ^0.5.6
-    version: 0.5.6(prettier-plugin-svelte@3.0.3)(prettier@3.0.3)
+    version: 0.5.6(prettier-plugin-svelte@3.0.3)(prettier@3.1.0)
   svelte:
     specifier: ^4.2.2
     version: 4.2.2
@@ -2160,17 +2160,17 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte@3.0.3(prettier@3.0.3)(svelte@4.2.2):
+  /prettier-plugin-svelte@3.0.3(prettier@3.1.0)(svelte@4.2.2):
     resolution: {integrity: sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
-      prettier: 3.0.3
+      prettier: 3.1.0
       svelte: 4.2.2
     dev: true
 
-  /prettier-plugin-tailwindcss@0.5.6(prettier-plugin-svelte@3.0.3)(prettier@3.0.3):
+  /prettier-plugin-tailwindcss@0.5.6(prettier-plugin-svelte@3.0.3)(prettier@3.1.0):
     resolution: {integrity: sha512-2Xgb+GQlkPAUCFi3sV+NOYcSI5XgduvDBL2Zt/hwJudeKXkyvRS65c38SB0yb9UB40+1rL83I6m0RtlOQ8eHdg==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
@@ -2222,12 +2222,12 @@ packages:
       prettier-plugin-twig-melody:
         optional: true
     dependencies:
-      prettier: 3.0.3
-      prettier-plugin-svelte: 3.0.3(prettier@3.0.3)(svelte@4.2.2)
+      prettier: 3.1.0
+      prettier-plugin-svelte: 3.0.3(prettier@3.1.0)(svelte@4.2.2)
     dev: true
 
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+  /prettier@3.1.0:
+    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -283,7 +283,7 @@
 								<span>{item.name}</span>
 							{:else}
 								<span
-									data-external="{isExternal}"
+									data-external={isExternal}
 									class="after:opacity-70 data-[external='true']:after:content-['↗']"
 								>
 									<a

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -233,7 +233,7 @@
 							<option class="bg-black/50" value="none">
 								{i("contact.fields.budget.none")}
 							</option>
-							<hr>
+							<hr />
 							<option class="bg-black/50" value="less">
 								{i("contact.fields.budget.less")}
 							</option>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -33,8 +33,8 @@ const routes = getRoutes("src/routes").map(route => {
 			route.path === ""
 				? 1
 				: new Date(route.lastMod).getTime() > Date.now() - 7 * 24 * 60 * 60 * 1000
-				? 0.8
-				: 0.7,
+				  ? 0.8
+				  : 0.7,
 		// Set the change frequency to weekly, unless the page has not been modified in the last month, in which case it is monthly
 		changeFreq:
 			new Date(route.lastMod).getTime() > Date.now() - 30 * 24 * 60 * 60 * 1000


### PR DESCRIPTION
[4 months after Prettier 3.0 and 2 months after the latest release](https://www.npmjs.com/package/prettier?activeTab=versions), Prettier finally [reimplements the plugin search feature](https://github.com/prettier/prettier/pull/15433#issuecomment-1732536900), allowing Svelte & TailwindCSS plugins to work as they did in v2, without having to specify the plugins in the command manually.
Our `Fix lint` workflow fix now works again, fixing in the meantime the files that have not been formatted in our editors for 4 months, in addition to formatting using the [improved ternary rules](https://prettier.io/blog/2023/11/13/3.1.0#javascript) in 3.1 ([other improvements](https://prettier.io/blog/2023/11/13/3.1.0#other-changes)).

> I still cannot stop enjoying how the CI progressively fixes the PR by itself, allowing me to only have to bump the `package.json` from the GitHub website to get everything to work!