### PR TITLE
Fix icons hover not updating on scroll in Technos section on Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emerald-website",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"private": true,
 	"scripts": {
 		"dev": "vite",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -276,17 +276,6 @@
 			interval = setInterval(autoScroll, DELAY);
 		});
 
-		// Add listeners to the icons to start/stop the interval on hover
-		[...technoIcons.children].forEach(icon => {
-			icon.addEventListener("mouseenter", () => {
-				clearInterval(interval);
-			});
-
-			icon.addEventListener("mouseleave", () => {
-				interval = setInterval(autoScroll, DELAY);
-			});
-		});
-
 		// Scroll handler to update the hovered icon depending on
 		// the card we scrolled to
 		function onTechnoCardsScrollEnd() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -289,13 +289,24 @@
 
 		// Scroll handler to update the hovered icon depending on
 		// the card we scrolled to
-		technoCards.addEventListener("scrollend", () => {
-			if (!technoCards) return; // fix "scrollLeft not found on undefined"?
+		function onTechnoCardsScrollEnd() {
+			if (!technoCards) return; // fix "scrollLeft not found on undefined"
 			const scrollDistance = technoCards.scrollLeft;
 			const containerWidth = technoCards.clientWidth;
 			currentCard = Math.round(scrollDistance / containerWidth);
 			hoverIcon(currentCard);
-		});
+		}
+
+		if ("onscrollend" in window) {
+			technoCards.addEventListener("scrollend", onTechnoCardsScrollEnd);
+		} else {
+			// Safari fallback
+			let i: ReturnType<typeof setTimeout>;
+			technoCards.addEventListener("scroll", () => {
+				clearTimeout(i);
+				i = setTimeout(onTechnoCardsScrollEnd, 100);
+			});
+		}
 
 		// On destroy, clear the interval
 		return () => clearInterval(interval);


### PR DESCRIPTION
I noticed on my iPhone that the icons were not getting their hover effect moved from one another in the Technologies section a few weeks ago.

I took a look today and noticed it was indeed not working not only in Safari for iOS but also in Safari desktop.

The code that's supposed to do it is in the `technoCards.addEventListener("scrollend", () => {});` handler. After investigation on potential causes, it turned out that the `"scrollend"` event was not working because it's [simply not implemented in Safari yet](https://caniuse.com/mdn-api_element_scrollend_event). To my surprise, it's only existed since [January 2023](https://developer.chrome.com/blog/scrollend-a-new-javascript-event/), which is still very recent.

The workaround is simple, [provided by this very article from Chrome for Developers](https://developer.chrome.com/blog/scrollend-a-new-javascript-event/#polyfills-and-progressive-enhancement). I implemented a slightly opinionated version of it, and it just works.

---
I also take profit from this PR to remove the "stop scrolling cards on hover of the icons" feature, because it's annoying on mobile (`"mouseleave"` is only triggered when clicking outside of the icons) and because it's simply not even useful with a mouse.