### PR TITLE
infra: Add package.json to ignored paths of title modifier workflow

### DIFF
--- a/.github/workflows/pr-title-changer.yml
+++ b/.github/workflows/pr-title-changer.yml
@@ -6,6 +6,7 @@ on:
       - src/**
       - static/**
       - tailwind.config.*
+      - package.json
 
 env:
   PREFIX: infra


### PR DESCRIPTION
Add `package.json` to the list of files _not_ triggering the `PR Title Modifier` workflow, avoiding the change to an infra PR when we bump the version.

It won't affect the dependencies bump, because those _always_ come along with a modification of the `pnpm-lock.yaml` lock file (either by bots or by the `pre-checks` workflow), which is not ignored by this rule.