### PR TITLE
infra: Add dependencies to workflow lint step

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -143,11 +143,15 @@ jobs:
         run: |
           code_changes=false
           config_changes=false
+          deps_changes=false
 
           for file in ${{ steps.modified-files.outputs.all_changed_files }}; do
             if [[ $file =~ ^src/ || $file =~ ^static/ ]]; then
               echo "$file changes code"
               code_changes=true
+            elif [[ $file = pnpm-lock.yaml ]]; then
+              echo "$file changes dependencies"
+              deps_changes=true
             elif [[ $file = *.config.*s || $file = tsconfig.json ]]; then
               echo "$file changes config"
               config_changes=true
@@ -160,13 +164,14 @@ jobs:
 
           echo "code_changes=$code_changes" >> $GITHUB_OUTPUT
           echo "config_changes=$config_changes" >> $GITHUB_OUTPUT
+          echo "deps_changes=$deps_changes" >> $GITHUB_OUTPUT
 
       - name: ✨ Check Svelte format
         if: steps.changed-files.outputs.code_changes == 'true'
         run: pnpm check
 
       - name: ✨ Check style with Prettier & ESLint
-        if: steps.changed-files.outputs.code_changes == 'true' || steps.changed-files.outputs.config_changes == 'true'
+        if: steps.changed-files.outputs.code_changes == 'true' || steps.changed-files.outputs.config_changes == 'true' || steps.changed-files.outputs.deps_changes == 'true'
         run: pnpm lint
 
       - name: 🔧 Fix lint
@@ -205,7 +210,7 @@ jobs:
           requires_build=false
 
           for file in ${{ steps.modified-files.outputs.all_changed_files }}; do
-            if [[ $file =~ ^src/ || $file =~ ^static/ || $file = package.json || $file = pnpm-lock.yaml || $file = *.config.*s || $file = tsconfig.json ]]; then
+            if [[ $file =~ ^src/ || $file =~ ^static/ || $file = pnpm-lock.yaml || $file = *.config.*s || $file = tsconfig.json ]]; then
               echo "$file requires build"
               requires_build=true
               break


### PR DESCRIPTION
Self explanatory, add (back) any dependency change to the list of changes triggering the `Check lint` workflow step.

It’s useful when ESLint/Prettier or their plugins are updated from the bots’ PRs: we need to know if they introduce breaking changes.

Also, remove `package.json` from the list of files requiring the build of the repo, because as mentioned in #189, if a dependency is changed the lock file will be changed too, and we don’t want a version bump to trigger a whole build for nothing.