### PR TITLE
Improve logic for navigating from SlideOver

### DIFF
--- a/src/lib/shells/SlideOver.svelte
+++ b/src/lib/shells/SlideOver.svelte
@@ -17,14 +17,18 @@
 	 * The optional title of the slide over, displayed in the header.
 	 */
 	export let title: string | undefined = undefined;
-
-	function close() {
-		show = false;
-	}
+	/**
+	 * The callback function to call when the slideover opened.
+	 */
+	export let afterOpen: () => void = () => {};
+	/**
+	 * The callback function to call when the slideover closed.
+	 */
+	export let afterClose: () => void = () => {};
 </script>
 
 <Transition {show}>
-	<Dialog class="relative z-10" on:close={close}>
+	<Dialog class="relative z-10" on:close={() => (show = false)}>
 		<TransitionChild
 			enter="ease-in-out duration-500"
 			enterFrom="opacity-0"
@@ -46,6 +50,8 @@
 						leave="ease-in-out duration-500 sm:duration-700"
 						leaveFrom="translate-x-0"
 						leaveTo="translate-x-full"
+						on:introend={afterOpen}
+						on:outroend={afterClose}
 					>
 						<!-- FIXME: close on click not working for some reason (lib bug or height/placement issue?) -->
 						<div class="pointer-events-auto h-full w-screen max-w-md">
@@ -56,7 +62,11 @@
 											{title}
 										</DialogTitle>
 										<div class="ml-3 flex h-7 items-center">
-											<button type="button" class="-m-2 p-2 hover:opacity-75" on:click={close}>
+											<button
+												type="button"
+												class="-m-2 p-2 hover:opacity-75"
+												on:click={() => (show = false)}
+											>
 												<span class="sr-only">{i("a11y.aria.panel-close")}</span>
 												<XMark class="h-6 w-6" aria-hidden="true" />
 											</button>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -242,13 +242,13 @@
 					type="button"
 					class="relative after:absolute after:-bottom-1.5 after:left-0 after:h-1 after:w-0 after:bg-dominant after:duration-300 after:content-[''] hover:after:w-full"
 					on:click={() => {
-						showSlideOver = false;
 						slideOverCloseCallback = async () => {
 							if ($page.route.id !== "/") {
 								await goto("/");
 							}
 							scrollTo(item.href);
 						};
+						showSlideOver = false;
 					}}
 				>
 					{item.name}
@@ -258,8 +258,8 @@
 				type="button"
 				class="relative text-dominant after:absolute after:-bottom-1.5 after:left-0 after:h-1 after:w-0 after:bg-dominant after:duration-300 after:content-[''] hover:after:w-full"
 				on:click={() => {
-					showSlideOver = false;
 					slideOverCloseCallback = () => goto("/contact");
+					showSlideOver = false;
 				}}
 			>
 				{i("common.contact")}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -78,6 +78,7 @@
 
 	$: showButton = scrollY >= scrollDistanceContactButton;
 	let showSlideOver = false;
+	let slideOverCloseCallback: () => void = () => {};
 
 	let shrinkNavBar = false;
 
@@ -225,7 +226,13 @@
 </div>
 
 <!-- Responsive slide-over -->
-<SlideOver bind:show={showSlideOver}>
+<SlideOver
+	bind:show={showSlideOver}
+	afterClose={() => {
+		slideOverCloseCallback();
+		slideOverCloseCallback = () => {};
+	}}
+>
 	<svelte:fragment slot="content">
 		<div
 			class="flex h-full flex-col items-center justify-center gap-20 text-4xl font-medium child:after:!-bottom-3 child:after:!h-2"
@@ -236,12 +243,12 @@
 					class="relative after:absolute after:-bottom-1.5 after:left-0 after:h-1 after:w-0 after:bg-dominant after:duration-300 after:content-[''] hover:after:w-full"
 					on:click={() => {
 						showSlideOver = false;
-						setTimeout(async () => {
+						slideOverCloseCallback = async () => {
 							if ($page.route.id !== "/") {
 								await goto("/");
 							}
 							scrollTo(item.href);
-						}, 300);
+						};
 					}}
 				>
 					{item.name}
@@ -252,7 +259,7 @@
 				class="relative text-dominant after:absolute after:-bottom-1.5 after:left-0 after:h-1 after:w-0 after:bg-dominant after:duration-300 after:content-[''] hover:after:w-full"
 				on:click={() => {
 					showSlideOver = false;
-					setTimeout(() => goto("/contact"), 300);
+					slideOverCloseCallback = () => goto("/contact");
 				}}
 			>
 				{i("common.contact")}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -290,10 +290,10 @@
 			technoCards.addEventListener("scrollend", onTechnoCardsScrollEnd);
 		} else {
 			// Safari fallback
-			let i: ReturnType<typeof setTimeout>;
+			let timeout: ReturnType<typeof setTimeout>;
 			technoCards.addEventListener("scroll", () => {
-				clearTimeout(i);
-				i = setTimeout(onTechnoCardsScrollEnd, 100);
+				clearTimeout(timeout);
+				timeout = setTimeout(onTechnoCardsScrollEnd, 100);
 			});
 		}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -290,10 +290,10 @@
 			technoCards.addEventListener("scrollend", onTechnoCardsScrollEnd);
 		} else {
 			// Safari fallback
-			let timeout: ReturnType<typeof setTimeout>;
+			let i: ReturnType<typeof setTimeout>;
 			technoCards.addEventListener("scroll", () => {
-				clearTimeout(timeout);
-				timeout = setTimeout(onTechnoCardsScrollEnd, 100);
+				clearTimeout(i);
+				i = setTimeout(onTechnoCardsScrollEnd, 100);
 			});
 		}
 


### PR DESCRIPTION
Improve the logic used to navigate to an item from the responsive slide-over to reduce the amount of `setTimeout`s (and `setInterval`s) in the code, which are neither clean nor optimized.

Introduce callbacks powered by Svelte Headless UI to accurately get the right timing when the slide-over opens or closes. I'm moderately proud of the resulting code, if you find a cleaner way instead of resetting the function as I'm doing, don't hesitate to tell me.

This is the only place where it was a poor optimizable logic and not a requirement.

### Additional change
I also took advantage of this PR to remove the `close()` function in `SlideOver.svelte`, preferring duplicating and inlining twice than cluttering the `<script>` tag. Feel free to tell me if you prefer it rolled back.