### PR TITLE
Fix Technologies carousel auto-scroll not resetting on click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "emerald-website",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"private": true,
 	"scripts": {
 		"dev": "vite",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -211,10 +211,11 @@
 	}
 
 	// Auto-scroll technologies cards
-	const DELAY = 5000;
-	let currentCard = 0;
+	const TECHNO_AUTO_SCROLL_DELAY = 5000;
+	let currentTechnoCard = 0;
+	let shouldResetTechnoScrollTimer = false;
 
-	function hoverIcon(index: number) {
+	function hoverTechnoIcon(index: number) {
 		const icons = technoIcons.children;
 		if (!icons || icons.length < index) return;
 		const icon = icons[index];
@@ -227,7 +228,7 @@
 		}
 	}
 
-	function scrollToCard(index: number) {
+	function scrollToTechnoCard(index: number) {
 		const cards = technoCards?.children;
 		if (!cards || cards.length < index) return;
 		const card = cards[index];
@@ -251,20 +252,20 @@
 
 		// Hover the first icon on load, otherwise
 		// no icon is hovered until the first scroll
-		hoverIcon(currentCard);
+		hoverTechnoIcon(currentTechnoCard);
 
 		// Auto-scroll function
-		const autoScroll = () => {
-			if (currentCard === cards.length - 1) {
-				currentCard = 0;
+		function autoScroll() {
+			if (currentTechnoCard === cards.length - 1) {
+				currentTechnoCard = 0;
 			} else {
-				currentCard++;
+				currentTechnoCard++;
 			}
-			scrollToCard(currentCard);
-		};
+			scrollToTechnoCard(currentTechnoCard);
+		}
 
 		// Initial interval definition, start auto-scrolling
-		let interval = setInterval(autoScroll, DELAY);
+		let interval = setInterval(autoScroll, TECHNO_AUTO_SCROLL_DELAY);
 
 		// Stop the interval on hover of the cards
 		technoCards.addEventListener("mouseenter", () => {
@@ -273,27 +274,32 @@
 
 		// Restart the interval on mouse leave
 		technoCards.addEventListener("mouseleave", () => {
-			interval = setInterval(autoScroll, DELAY);
+			interval = setInterval(autoScroll, TECHNO_AUTO_SCROLL_DELAY);
 		});
 
 		// Scroll handler to update the hovered icon depending on
 		// the card we scrolled to
 		function onTechnoCardsScrollEnd() {
+			if (shouldResetTechnoScrollTimer) {
+				clearInterval(interval);
+				interval = setInterval(autoScroll, TECHNO_AUTO_SCROLL_DELAY);
+				shouldResetTechnoScrollTimer = false;
+			}
 			if (!technoCards) return; // fix "scrollLeft not found on undefined"
 			const scrollDistance = technoCards.scrollLeft;
 			const containerWidth = technoCards.clientWidth;
-			currentCard = Math.round(scrollDistance / containerWidth);
-			hoverIcon(currentCard);
+			currentTechnoCard = Math.round(scrollDistance / containerWidth);
+			hoverTechnoIcon(currentTechnoCard);
 		}
 
 		if ("onscrollend" in window) {
 			technoCards.addEventListener("scrollend", onTechnoCardsScrollEnd);
 		} else {
 			// Safari fallback
-			let i: ReturnType<typeof setTimeout>;
+			let timeout: ReturnType<typeof setTimeout>;
 			technoCards.addEventListener("scroll", () => {
-				clearTimeout(i);
-				i = setTimeout(onTechnoCardsScrollEnd, 100);
+				clearTimeout(timeout);
+				timeout = setTimeout(onTechnoCardsScrollEnd, 100);
 			});
 		}
 
@@ -602,7 +608,10 @@
 						class="group absolute flex aspect-square h-1/2 items-center justify-center rounded-full bg-gray-400/75 transition-all duration-700
 						hover:bg-gray-500 hover:scale-110
 						[&.is-selected]:z-10 [&.is-selected]:bg-gray-600 [&.is-selected]:scale-110"
-						on:click={() => scrollToCard(index)}
+						on:click={() => {
+							scrollToTechnoCard(index);
+							shouldResetTechnoScrollTimer = true;
+						}}
 					>
 						<svelte:component
 							this={techno.icon}


### PR DESCRIPTION
Since the recent removal of the `"mouseleave"` event on the icons of the Technologies section in #187, clicking an icon to slide to another card doesn't reset the auto-scroll feature's timer, leading to some weird behavior of the carousel not taking in account our latest card slide.

To fix this, I'm introducing a new boolean variable called `shouldResetTechnoScrollTimer`, which is set to `true` if and only if a card is being moved from clicking an icon. Then, when the scroll ends, if this variable is true (if the card move has been triggered from an icon click), I reset the `setInterval` and set the variable back to false.

As such, it should fix the issue without causing the drawbacks we met with `"mouseleave"` on mobile.

I also used this PR to rename a bunch of variables, making what they belong to clearer.

~~The change is untested as implemented directly from the GitHub website at 1:30 AM, but it should work flawlessly.~~ **Update: it doesn't exactly. The timer is indeed reset, but it does not prevent an auto-scroll from happening DURING a slide: the timer is only reset when the scroll ENDS, not when it STARTS. The ideal solution would be:**
```ts
// only if shouldResetTechnoScrollTimer
on("clickOnIcon", () => {
	clearInterval(interval);
});
on("scrollend", () => {
	startInterval();
	...
});
```
**however, I cannot think of a perfect solution without `"mouseleave"` and without refactoring everything out of `onMount`. Let me know if you can find a better fix.**

Just so you know, this PR will also bump the website version, so it must be merged last.