### PR TITLE
Replace JS calculation with scroll margins

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -8,6 +8,10 @@
 		@apply bg-dominant/75 text-primary;
 	}
 
+	html {
+		@apply motion-safe:scroll-smooth;
+	}
+
 	body {
 		@apply bg-primary text-primary;
 	}

--- a/src/lib/layouts/Section.svelte
+++ b/src/lib/layouts/Section.svelte
@@ -1,6 +1,6 @@
 <section
 	id={$$props.id}
-	class="py-16 *:mx-16 md:*:mx-32 xxl:*:!mx-auto xxl:*:max-w-screen-2xl
+	class="scroll-mt-10 py-16 *:mx-16 sm:scroll-mt-16 md:scroll-mt-24 md:*:mx-32 xxl:*:!mx-auto xxl:*:max-w-screen-2xl
 	{$$props.class ?? ''}"
 >
 	{#if $$slots.title}

--- a/src/lib/utils/scroll.ts
+++ b/src/lib/utils/scroll.ts
@@ -1,8 +1,8 @@
 /**
- * Scrolls to the specified element with a smooth behavior.
+ * Scrolls to the specified element.
  *
  * @param {string} selector - The CSS selector of the element to scroll to.
  */
 export function scrollTo(selector: string) {
-	document.querySelector(selector)?.scrollIntoView({ behavior: "smooth" });
+	document.querySelector(selector)?.scrollIntoView();
 }

--- a/src/lib/utils/scroll.ts
+++ b/src/lib/utils/scroll.ts
@@ -1,24 +1,8 @@
 /**
- * Scrolls to the specified element with a smooth animation, taking into account the height of the navbar if applicable.
- *
- * @function
- * @name scrollTo
+ * Scrolls to the specified element with a smooth behavior.
  *
  * @param {string} selector - The CSS selector of the element to scroll to.
  */
 export function scrollTo(selector: string) {
-	const element = document.querySelector(selector);
-	if (element) {
-		const navbar = document.getElementsByTagName("nav")[0];
-		if (navbar && selector.startsWith("#")) {
-			// The navbar is fixed, so we need to account for its height.
-			const navbarHeight =
-				navbar.getBoundingClientRect().top + navbar.getBoundingClientRect().height;
-			const scrollPosition = element.getBoundingClientRect().top - navbarHeight + window.scrollY;
-
-			window.scrollTo({ top: scrollPosition, behavior: "smooth" });
-		} else {
-			element.scrollIntoView({ behavior: "smooth" });
-		}
-	}
+	document.querySelector(selector)?.scrollIntoView({ behavior: "smooth" });
 }

--- a/src/lib/utils/scroll.ts
+++ b/src/lib/utils/scroll.ts
@@ -1,8 +1,0 @@
-/**
- * Scrolls to the specified element.
- *
- * @param {string} selector - The CSS selector of the element to scroll to.
- */
-export function scrollTo(selector: string) {
-	document.querySelector(selector)?.scrollIntoView();
-}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -110,12 +110,7 @@
 					type="button"
 					class="grid origin-left overflow-hidden scale-110 *:col-start-1 *:row-start-1 *:row-end-1"
 					on:click={() => {
-						$page.route.id === "/"
-							? window.scrollTo({
-									top: 0,
-									behavior: "smooth"
-								})
-							: goto("/");
+						$page.route.id === "/" ? window.scrollTo({ top: 0 }) : goto("/");
 					}}
 				>
 					{#if scrollY >= scrollDistanceLogoSwitch || (innerWidth > 0 && innerWidth < tailwindXsScreen)}
@@ -337,8 +332,8 @@
 		<button
 			type="button"
 			class="absolute bottom-0 left-0 right-0 mx-auto hidden w-fit text-center sm:block"
-			on:click={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-			on:keypress={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+			on:click={() => window.scrollTo({ top: 0 })}
+			on:keypress={() => window.scrollTo({ top: 0 })}
 		>
 			<ArrowUp
 				class="size-8 cursor-pointer rounded-full border-[1px] border-dominant p-1.5 text-dominant transition-colors duration-300 hover:border-transparent hover:bg-dominant hover:text-inverted"
@@ -349,8 +344,8 @@
 			<button
 				type="button"
 				class="sm:hidden"
-				on:click={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-				on:keypress={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+				on:click={() => window.scrollTo({ top: 0 })}
+				on:keypress={() => window.scrollTo({ top: 0 })}
 			>
 				<ArrowUp
 					class="size-8 cursor-pointer rounded-full border border-dominant p-1.5 text-dominant transition-colors duration-300 hover:border-transparent hover:bg-dominant hover:text-inverted"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,7 +4,6 @@
 	import Button from "$elements/Button.svelte";
 	import RadioButtonsGroup from "$elements/RadioButtonsGroup.svelte";
 	import SlideOver from "$shells/SlideOver.svelte";
-	import { scrollTo } from "$utils/scroll";
 	import { i, language, languages, loadResource, switchLanguage } from "@inlang/sdk-js";
 	import { ArrowUp, Bars3 } from "@inqling/svelte-icons/heroicon-24-solid";
 	import { Github } from "@inqling/svelte-icons/simple-icons";
@@ -160,7 +159,7 @@
 										if ($page.route.id !== "/") {
 											await goto("/");
 										}
-										scrollTo(item.href);
+										document.querySelector(item.href)?.scrollIntoView();
 									}
 								}}
 							>
@@ -241,7 +240,7 @@
 							if ($page.route.id !== "/") {
 								await goto("/");
 							}
-							scrollTo(item.href);
+							document.querySelector(item.href)?.scrollIntoView();
 						};
 						showSlideOver = false;
 					}}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -148,8 +148,7 @@
 		const leftScroll = processCards.scrollLeft - processCards.offsetWidth;
 		const rightScroll = processCards.scrollLeft + processCards.offsetWidth;
 		processCards.scrollTo({
-			left: button === "left" ? leftScroll : rightScroll,
-			behavior: "smooth"
+			left: button === "left" ? leftScroll : rightScroll
 		});
 	}
 
@@ -235,8 +234,7 @@
 		if (!card) return;
 
 		technoCards.scrollTo({
-			left: card.clientWidth * index,
-			behavior: "smooth"
+			left: card.clientWidth * index
 		});
 	}
 
@@ -475,7 +473,7 @@
 		</button>
 		<div
 			bind:this={processCards}
-			class="flex snap-x snap-mandatory gap-16 overflow-x-auto overflow-y-hidden py-8 *:snap-start lg:justify-center"
+			class="flex snap-x snap-mandatory gap-16 overflow-x-auto overflow-y-hidden py-8 *:snap-start motion-safe:scroll-smooth lg:justify-center"
 		>
 			{#each processSections as { title, icon, description }, index}
 				<div class="relative max-lg:min-w-full lg:w-1/4 lg:pb-4">
@@ -578,7 +576,7 @@
 		<!-- Left part -->
 		<div
 			bind:this={technoCards}
-			class="flex max-w-full snap-x snap-mandatory gap-8 overflow-x-auto py-4 *:snap-start sm:max-w-none"
+			class="flex max-w-full snap-x snap-mandatory gap-8 overflow-x-auto py-4 *:snap-start motion-safe:scroll-smooth sm:max-w-none"
 		>
 			{#each technologiesSections as techno}
 				<div

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,6 @@
 	import MagneticElement from "$shells/MagneticElement.svelte";
 	import Mouse3DTilting from "$shells/Mouse3DTilting.svelte";
 	import Section from "$layouts/Section.svelte";
-	import { scrollTo } from "$utils/scroll";
 	import Button from "$elements/Button.svelte";
 	import {
 		Cloud,
@@ -450,8 +449,8 @@
 					transition-property: transform;
 					transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 				"
-			on:keypress={() => scrollTo("#process")}
-			on:click={() => scrollTo("#process")}
+			on:keypress={() => document.querySelector("#process")?.scrollIntoView()}
+			on:click={() => document.querySelector("#process")?.scrollIntoView()}
 		>
 			<ArrowDown
 				class="size-8 cursor-pointer rounded-full border border-transparent bg-dominant p-1.5 text-inverted


### PR DESCRIPTION
I recently discovered (the meaning of) `scroll-padding(-X)` and `scroll-margin(-X)` CSS properties in a [Kevin Powell's video](https://youtu.be/cCAtD_BAHNw?si=6JgemZgs0pZRdv8H&t=370). I instantly realized that THIS is what we need instead of our `scroll.ts` file, so make the scroll offset by a bit _and_ more accessible with CSS only.

So that's what I just did: get rid of `scroll.ts` because the function would only contain 1 line and we already use other JS scroll methods elsewhere to scroll to the top or within carousels.

### What we win
- Better accessibility with `prefers-reduce-motion`
- JS-less smooth scroll
- Less computation
- Fewer abstractions
- Less code

### What we lose
- A file

Looks like a win to me!