### PR TITLE
Update ignores in ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,6 @@ export default [
 		}
 	},
 	{
-		ignores: ["build/", ".svelte-kit/", "package/", "src/paraglide/"]
+		ignores: ["build/", ".svelte-kit/", "dist/", "src/paraglide/"]
 	}
 ];


### PR DESCRIPTION
Quick update to the `ignores` list in the `eslint.config.js` to reflect the latest SvelteKit changes (before they rolled back to ESLint v8 - check the PR in the commit description for reference)