### PR TITLE
infra: Little improvements

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -72,8 +72,6 @@ jobs:
 
       - name: 📥 Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: 🧭 Setup Node
         uses: actions/setup-node@v4
@@ -241,8 +239,6 @@ jobs:
       - name: 📥 Install pnpm
         if: steps.changed-files.outputs.requires_build == 'true'
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: 🧭 Setup Node
         if: steps.changed-files.outputs.requires_build == 'true'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,10 +6,10 @@ import globals from "globals";
 
 export default tseslint.config(
 	eslint.configs.recommended,
-	...tseslint.configs.recommended,
-	...svelte.configs["flat/recommended"],
+	tseslint.configs.recommended,
+	svelte.configs["flat/recommended"],
 	prettierConfig,
-	...svelte.configs["flat/prettier"],
+	svelte.configs["flat/prettier"],
 	{
 		languageOptions: {
 			globals: {

--- a/package.json
+++ b/package.json
@@ -7,18 +7,16 @@
 		"dev-exposed": "vite --host",
 		"build": "vite build",
 		"preview": "vite preview",
-		"deps:install": "pnpm i",
-		"deps:update": "pnpm up",
-		"deps:update-latest": "pnpm up -L",
 		"check": "svelte-kit sync && svelte-check --tsconfig tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
-		"prepare": "husky"
+		"prepare": "svelte-kit sync && husky"
 	},
 	"devDependencies": {
-		"@inlang/paraglide-js": "^1.11.3",
-		"@inlang/paraglide-sveltekit": "^0.8.7",
+		"@eslint/js": "^9.18.0",
+		"@inlang/paraglide-js": "^1.11.8",
+		"@inlang/paraglide-sveltekit": "0.8.7",
 		"@inqling/svelte-icons": "<= 4.1.2 || >= 4.1.4",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.16.0",
@@ -32,7 +30,6 @@
 		"eslint-plugin-svelte": "^2.46.1",
 		"globals": "^15.14.0",
 		"husky": "^9.1.7",
-		"just-extend": "^6.2.0",
 		"mini-svg-data-uri": "^1.4.4",
 		"postcss": "^8.5.1",
 		"postcss-import": "^16.1.0",
@@ -52,5 +49,11 @@
 		"vaul-svelte": "^0.3.2",
 		"vite": "^6.0.7"
 	},
-	"type": "module"
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"esbuild"
+		]
+	},
+	"type": "module",
+	"packageManager": "pnpm@10.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,14 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.18.0
       '@inlang/paraglide-js':
-        specifier: ^1.11.3
-        version: 1.11.3
+        specifier: ^1.11.8
+        version: 1.11.8
       '@inlang/paraglide-sveltekit':
-        specifier: ^0.8.7
+        specifier: 0.8.7
         version: 0.8.7(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@20.12.7)(jiti@1.21.7)))(svelte@5.19.0)(vite@6.0.7(@types/node@20.12.7)(jiti@1.21.7)))
       '@inqling/svelte-icons':
         specifier: <= 4.1.2 || >= 4.1.4
@@ -53,9 +56,6 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
-      just-extend:
-        specifier: ^6.2.0
-        version: 6.2.0
       mini-svg-data-uri:
         specifier: ^1.4.4
         version: 1.4.4
@@ -368,8 +368,13 @@ packages:
     peerDependencies:
       '@sinclair/typebox': ^0.31.17
 
-  '@inlang/paraglide-js@1.11.3':
-    resolution: {integrity: sha512-WVNraTylfZty0kt5EQNh8yx0WUJbtYEmc8YoNRRSUWB0rqeCh8a9xIQnmzZxBMf7IL7es+Ppiqx15py7mukJRw==}
+  '@inlang/module@1.2.14':
+    resolution: {integrity: sha512-Z7rRa6x3RkzjdvNA7x+KskNGdSBEO46X9c7bTl6eZmLXy0J9yGDn6s4jpYqQzyKRG8g5mEqWcRqcVqdNwzj5Gg==}
+    peerDependencies:
+      '@sinclair/typebox': ^0.31.17
+
+  '@inlang/paraglide-js@1.11.8':
+    resolution: {integrity: sha512-PxzrmDP63fbMNF4/AtiLFTnUodFxVbOkLpIrOzPZvNuLg0wCWnsaBfNT87/rNjL/A7ZPzEBmuDi0P2pn8iB0Fw==}
     hasBin: true
 
   '@inlang/paraglide-js@1.9.1':
@@ -388,8 +393,16 @@ packages:
   '@inlang/paraglide-vite@1.2.63':
     resolution: {integrity: sha512-2GOzjBSiGLEHUxuOPH64L6p48HAXhfeLCvJpPJPC0CkW1UnBPSnY64k5fbWAkpNDQZ4BOyyQX3C9io24vRsXxg==}
 
+  '@inlang/plugin-message-format@2.2.0':
+    resolution: {integrity: sha512-6MJLExr3OLqbR8gCP4UEgNMgdaJFFCug2GLmFwid7Ana4kObnbCA33YN3m3eN8p+lmnv7zpfW7oeyTZXZLoptg==}
+
   '@inlang/plugin@2.4.13':
     resolution: {integrity: sha512-mSe9cQBvVYskmKds/f5qxDnMXdewLS09KXSi9lcB8YUSiAO1o1WskdhWRWHL8lgmENS44xuHIiFHYdQFtGw/6Q==}
+    peerDependencies:
+      '@sinclair/typebox': ^0.31.17
+
+  '@inlang/plugin@2.4.14':
+    resolution: {integrity: sha512-HFI1t1tKs6jXqwKVl59vvt7kvMgg2Po7xA3IFijfJTZCt0tTI8txqeXCUV9jhUop29Hqj6a5zQd32BYv33Dulw==}
     peerDependencies:
       '@sinclair/typebox': ^0.31.17
 
@@ -398,11 +411,29 @@ packages:
     peerDependencies:
       '@sinclair/typebox': ^0.31.17
 
+  '@inlang/recommend-ninja@0.1.1':
+    resolution: {integrity: sha512-dthW8SA6LHUhPFXwKxYy92PG4dg4KeIS0jbgpplXxgoQAeouP6DHEa87kva2DXbk3kUbNz+/MFPjyaygBfamog==}
+
+  '@inlang/recommend-sherlock@0.1.1':
+    resolution: {integrity: sha512-8qZ8FJ/QqVh6YqKmHo3SxI4ENM0O80TCzETm+hxeQ2JzPKPFYucFINpLvUygiLFp/hJwhoI5TjRz6jNI2QdfMQ==}
+
   '@inlang/result@1.1.0':
     resolution: {integrity: sha512-zLGroi9EUiHuOjUOaglUVTFO7EWdo2OARMJLBO1Q5Ga/xJmSQb6XS1lhqEXBFAjgFarfEMX5YEJWWALogYV3wA==}
 
   '@inlang/sdk@0.35.5':
     resolution: {integrity: sha512-zCpqVxmx5f9hGmFx23H7B81YaTF52bZOIePJZa9Ma9WoBXXf63cKL3rJDdmJtxfMsGzL0S4ZsqngNtBphqIf2Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@inlang/sdk@0.36.3':
+    resolution: {integrity: sha512-wjsavc44H24v74tdEQ13FqZZcr43T106oEfHJnBLzEP55Zz2JJWABLund+DEdosZx+9E8mJBEW5JlVnlBwP3Zw==}
+    engines: {node: '>=18.0.0'}
+
+  '@inlang/sdk@0.36.4':
+    resolution: {integrity: sha512-fTr0mkDx2ViZt/8lxaF9Mxj3m8LaqIhcjMJy+CdHREMc9UvpUhGLB7elMp061YysxnN1CFccAgLRug5VWK3yWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@inlang/sdk@0.37.0':
+    resolution: {integrity: sha512-/uG/9HrJU+v5jY/nWKZAlI3diD8WdT5bAYuIZ3rVsnphvqV4iWvQwAp3H/K8F5QDJ+GEY79mhKfFhHcKMSiWng==}
     engines: {node: '>=18.0.0'}
 
   '@inlang/translatable@1.3.1':
@@ -441,8 +472,14 @@ packages:
   '@lix-js/client@2.2.0':
     resolution: {integrity: sha512-RuSofz4n8DQcwySvBpg1DFzqF92nbCpDj3lApD5x0BKaTvByQNBPeNvXON1Jtgxj3folmEWqND54AysF0TwMKQ==}
 
+  '@lix-js/client@2.2.1':
+    resolution: {integrity: sha512-6DTJdRN2L2a1A8OxW1Wqh3ZOORqq8+YlCALMF5UMoxhfHE4Fcq9FZztMkAV+KwhrDSsp0USWvD9myG0XX+v6QQ==}
+
   '@lix-js/fs@2.1.0':
     resolution: {integrity: sha512-HPp5y3KsssmzHt5VI9+eM7Tisx9meET8eWimMrAizCwNx3OheGFXofprOt9+64AIgxwifb97/lmv87yY5MJqHA==}
+
+  '@lix-js/fs@2.2.0':
+    resolution: {integrity: sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==}
 
   '@melt-ui/svelte@0.76.2':
     resolution: {integrity: sha512-7SbOa11tXUS95T3fReL+dwDs5FyJtCEqrqG3inRziDws346SYLsxOQ6HmX+4BkIsQh1R8U3XNa+EMmdMt38lMA==}
@@ -860,6 +897,9 @@ packages:
     resolution: {integrity: sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==}
     engines: {node: '>=8'}
 
+  array-timsort@1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
@@ -1004,6 +1044,10 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  comment-json@4.2.5:
+    resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
+    engines: {node: '>= 6'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1014,6 +1058,9 @@ packages:
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -1196,6 +1243,11 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
@@ -1337,6 +1389,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-own-prop@2.0.0:
+    resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
+    engines: {node: '>=8'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -1429,9 +1485,6 @@ packages:
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
-
-  just-extend@6.2.0:
-    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
 
   jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
@@ -1828,6 +1881,10 @@ packages:
   reduce-flatten@2.0.0:
     resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
     engines: {node: '>=6'}
+
+  repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2375,9 +2432,22 @@ snapshots:
       '@inlang/plugin': 2.4.13(@sinclair/typebox@0.31.28)
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/paraglide-js@1.11.3':
+  '@inlang/module@1.2.14(@sinclair/typebox@0.31.28)':
+    dependencies:
+      '@inlang/message-lint-rule': 1.4.7(@sinclair/typebox@0.31.28)
+      '@inlang/plugin': 2.4.14(@sinclair/typebox@0.31.28)
+      '@sinclair/typebox': 0.31.28
+
+  '@inlang/paraglide-js@1.11.8':
     dependencies:
       '@inlang/detect-json-formatting': 1.0.0
+      '@inlang/language-tag': 1.5.1
+      '@inlang/plugin-message-format': 2.2.0
+      '@inlang/recommend-ninja': 0.1.1
+      '@inlang/recommend-sherlock': 0.1.1
+      '@inlang/sdk': 0.37.0
+      '@lix-js/client': 2.2.1
+      '@lix-js/fs': 2.2.0
       commander: 11.1.0
       consola: 3.2.3
       dedent: 1.5.1
@@ -2386,6 +2456,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - debug
+      - supports-color
 
   '@inlang/paraglide-js@1.9.1':
     dependencies:
@@ -2408,7 +2479,7 @@ snapshots:
       commander: 12.1.0
       dedent: 1.5.1
       devalue: 4.3.2
-      magic-string: 0.30.12
+      magic-string: 0.30.17
       svelte: 5.19.0
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -2434,6 +2505,8 @@ snapshots:
       - debug
       - supports-color
 
+  '@inlang/plugin-message-format@2.2.0': {}
+
   '@inlang/plugin@2.4.13(@sinclair/typebox@0.31.28)':
     dependencies:
       '@inlang/json-types': 1.1.0(@sinclair/typebox@0.31.28)
@@ -2444,11 +2517,42 @@ snapshots:
       '@lix-js/fs': 2.1.0
       '@sinclair/typebox': 0.31.28
 
+  '@inlang/plugin@2.4.14(@sinclair/typebox@0.31.28)':
+    dependencies:
+      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.31.28)
+      '@inlang/language-tag': 1.5.1
+      '@inlang/message': 2.1.0(@sinclair/typebox@0.31.28)
+      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.31.28)
+      '@inlang/translatable': 1.3.1
+      '@lix-js/fs': 2.2.0
+      '@sinclair/typebox': 0.31.28
+
   '@inlang/project-settings@2.4.2(@sinclair/typebox@0.31.28)':
     dependencies:
       '@inlang/json-types': 1.1.0(@sinclair/typebox@0.31.28)
       '@inlang/language-tag': 1.5.1
       '@sinclair/typebox': 0.31.28
+
+  '@inlang/recommend-ninja@0.1.1':
+    dependencies:
+      '@inlang/sdk': 0.36.3
+      '@lix-js/client': 2.2.1
+      '@lix-js/fs': 2.2.0
+      '@sinclair/typebox': 0.31.28
+      js-yaml: 4.1.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  '@inlang/recommend-sherlock@0.1.1':
+    dependencies:
+      '@inlang/sdk': 0.36.4
+      '@lix-js/fs': 2.2.0
+      '@sinclair/typebox': 0.31.28
+      comment-json: 4.2.5
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   '@inlang/result@1.1.0': {}
 
@@ -2466,7 +2570,79 @@ snapshots:
       '@lix-js/client': 2.2.0
       '@lix-js/fs': 2.1.0
       '@sinclair/typebox': 0.31.28
-      debug: 4.3.7
+      debug: 4.4.0
+      dedent: 1.5.1
+      deepmerge-ts: 5.1.0
+      murmurhash3js: 3.0.1
+      solid-js: 1.6.12
+      throttle-debounce: 5.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  '@inlang/sdk@0.36.3':
+    dependencies:
+      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.31.28)
+      '@inlang/language-tag': 1.5.1
+      '@inlang/message': 2.1.0(@sinclair/typebox@0.31.28)
+      '@inlang/message-lint-rule': 1.4.7(@sinclair/typebox@0.31.28)
+      '@inlang/module': 1.2.14(@sinclair/typebox@0.31.28)
+      '@inlang/plugin': 2.4.14(@sinclair/typebox@0.31.28)
+      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.31.28)
+      '@inlang/result': 1.1.0
+      '@inlang/translatable': 1.3.1
+      '@lix-js/client': 2.2.1
+      '@lix-js/fs': 2.2.0
+      '@sinclair/typebox': 0.31.28
+      debug: 4.4.0
+      dedent: 1.5.1
+      deepmerge-ts: 5.1.0
+      murmurhash3js: 3.0.1
+      solid-js: 1.6.12
+      throttle-debounce: 5.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  '@inlang/sdk@0.36.4':
+    dependencies:
+      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.31.28)
+      '@inlang/language-tag': 1.5.1
+      '@inlang/message': 2.1.0(@sinclair/typebox@0.31.28)
+      '@inlang/message-lint-rule': 1.4.7(@sinclair/typebox@0.31.28)
+      '@inlang/module': 1.2.14(@sinclair/typebox@0.31.28)
+      '@inlang/plugin': 2.4.14(@sinclair/typebox@0.31.28)
+      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.31.28)
+      '@inlang/result': 1.1.0
+      '@inlang/translatable': 1.3.1
+      '@lix-js/client': 2.2.1
+      '@lix-js/fs': 2.2.0
+      '@sinclair/typebox': 0.31.28
+      debug: 4.4.0
+      dedent: 1.5.1
+      deepmerge-ts: 5.1.0
+      murmurhash3js: 3.0.1
+      solid-js: 1.6.12
+      throttle-debounce: 5.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  '@inlang/sdk@0.37.0':
+    dependencies:
+      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.31.28)
+      '@inlang/language-tag': 1.5.1
+      '@inlang/message': 2.1.0(@sinclair/typebox@0.31.28)
+      '@inlang/message-lint-rule': 1.4.7(@sinclair/typebox@0.31.28)
+      '@inlang/module': 1.2.14(@sinclair/typebox@0.31.28)
+      '@inlang/plugin': 2.4.14(@sinclair/typebox@0.31.28)
+      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.31.28)
+      '@inlang/result': 1.1.0
+      '@inlang/translatable': 1.3.1
+      '@lix-js/client': 2.2.1
+      '@lix-js/fs': 2.2.0
+      '@sinclair/typebox': 0.31.28
+      debug: 4.4.0
       dedent: 1.5.1
       deepmerge-ts: 5.1.0
       murmurhash3js: 3.0.1
@@ -2526,7 +2702,23 @@ snapshots:
       pify: 5.0.0
       sha.js: 2.4.11
 
+  '@lix-js/client@2.2.1':
+    dependencies:
+      '@lix-js/fs': 2.2.0
+      async-lock: 1.4.1
+      clean-git-ref: 2.0.1
+      crc-32: 1.2.2
+      ignore: 5.3.1
+      octokit: 3.1.2
+      pako: 1.0.11
+      pify: 5.0.0
+      sha.js: 2.4.11
+
   '@lix-js/fs@2.1.0':
+    dependencies:
+      typescript: 5.2.2
+
+  '@lix-js/fs@2.2.0':
     dependencies:
       typescript: 5.2.2
 
@@ -2986,6 +3178,8 @@ snapshots:
 
   array-back@4.0.2: {}
 
+  array-timsort@1.0.3: {}
+
   async-lock@1.4.1: {}
 
   asynckit@0.4.0: {}
@@ -3138,11 +3332,21 @@ snapshots:
 
   commander@4.1.1: {}
 
+  comment-json@4.2.5:
+    dependencies:
+      array-timsort: 1.0.3
+      core-util-is: 1.0.3
+      esprima: 4.0.1
+      has-own-prop: 2.0.0
+      repeat-string: 1.6.1
+
   concat-map@0.0.1: {}
 
   consola@3.2.3: {}
 
   cookie@0.6.0: {}
+
+  core-util-is@1.0.3: {}
 
   crc-32@1.2.2: {}
 
@@ -3342,6 +3546,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.12.1)
       eslint-visitor-keys: 3.4.3
 
+  esprima@4.0.1: {}
+
   esquery@1.5.0:
     dependencies:
       estraverse: 5.3.0
@@ -3462,6 +3668,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-own-prop@2.0.0: {}
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -3541,8 +3749,6 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.6.3
-
-  just-extend@6.2.0: {}
 
   jwa@1.4.1:
     dependencies:
@@ -3833,6 +4039,8 @@ snapshots:
   readdirp@4.0.1: {}
 
   reduce-flatten@2.0.0: {}
+
+  repeat-string@1.6.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -4132,7 +4340,7 @@ snapshots:
 
   unplugin@1.5.1:
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.14.0
       chokidar: 3.6.0
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.6.2

--- a/src/lib/elements/button/Button.svelte
+++ b/src/lib/elements/button/Button.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import type { ButtonRootProps as ButtonProps } from "bits-ui";
-	import { twMerge } from "tailwind-merge";
+	import { type ClassNameValue, twMerge } from "tailwind-merge";
 
 	type Props = {
 		/**
 		 * Defines the style of the button. Defaults to `"primary"`.
 		 */
 		variant?: "primary" | "secondary" | "link";
-		class?: ButtonProps["class"];
+		class?: ClassNameValue;
 	} & ButtonProps;
 
 	let {

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import Button from "$elements/button";
 	import Mouse3DTilting from "$shells/Mouse3DTilting.svelte";
 	import CodeBracket from "@inqling/svelte-icons/heroicon-24-solid/code-bracket.svelte";
@@ -10,7 +10,7 @@
 </script>
 
 <svelte:head>
-	<title>{m.errorError()} {$page.status} | Emerald Studio</title>
+	<title>{m.errorError()} {page.status} | Emerald Studio</title>
 </svelte:head>
 
 <div
@@ -22,10 +22,10 @@
 		<h1
 			class="text-9xl font-semibold text-dominant xs:text-[12rem] sm:text-[14rem] md:text-[16rem]"
 		>
-			{$page.status}
+			{page.status}
 		</h1>
 		<h2 class="text-5xl font-medium xs:text-7xl md:text-8xl">
-			{$page.error?.message.toLowerCase()}
+			{page.error?.message.toLowerCase()}
 		</h2>
 	</div>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 	import "../app.css";
 	import { afterNavigate, beforeNavigate, goto } from "$app/navigation";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import ArrowUp from "@inqling/svelte-icons/heroicon-24-solid/arrow-up.svelte";
 	import Bars3 from "@inqling/svelte-icons/heroicon-24-solid/bars-3.svelte";
 	import Github from "@inqling/svelte-icons/simple-icons/github.svelte";
 	import { JsonLd, MetaTags, type JsonLdProps, type MetaTagsProps } from "svelte-meta-tags";
-	import extend from "just-extend";
 	import { ParaglideJS } from "@inlang/paraglide-sveltekit";
 	import { i18n } from "$utils/inlang";
 	import { availableLanguageTags, languageTag, onSetLanguageTag } from "$paraglide/runtime";
@@ -15,29 +14,25 @@
 	import SlideOver from "$shells/SlideOver.svelte";
 
 	// Breadcrumb
-	let currentRoute = $derived.by(() => {
-		if ($page.route.id) {
-			return $page.route.id.split("/").filter(Boolean);
-		}
-		return [];
-	});
+	let currentRoute = $derived(page.route.id?.split("/").filter(Boolean) ?? []);
 
 	// Meta tags
 	let { data, children } = $props();
-	let metadata: MetaTagsProps = $derived(
-		extend(true, {}, data.baseMetaTags, {
-			title: $page.data.pageTitle,
+	let metadata = $derived<MetaTagsProps>({
+		...data.baseMetaTags,
+		...{
+			title: page.data.pageTitle,
 			twitter: {
 				title:
-					data.baseMetaTags?.titleTemplate.replace(/%s/g, $page.data.pageTitle) ??
-					$page.data.pageTitle
+					data.baseMetaTags?.titleTemplate.replace(/%s/g, page.data.pageTitle) ??
+					page.data.pageTitle
 			}
-		})
-	);
+		}
+	});
 
 	let schema = $derived<JsonLdProps["schema"]>([
 		...data.baseSchemas,
-		...($page.data.pageSchemas ?? [])
+		...(page.data.pageSchemas ?? [])
 	]);
 
 	// Inlang
@@ -85,7 +80,7 @@
 	beforeNavigate(({ to, type }) => {
 		document.documentElement.classList.remove("motion-safe:scroll-smooth");
 		if (!to || !to.route.id) return; // to === null -> external link, to.route.id === null -> 404
-		if (type === "link" && to.route.id === $page.route.id) {
+		if (type === "link" && to.route.id === page.route.id) {
 			const lang = i18n.getLanguageFromUrl(to.url);
 			localStorage.setItem("language", lang);
 		}
@@ -143,11 +138,11 @@
 				<div class="mr-auto flex items-center gap-5">
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<svelte:element
-						this={$page.route.id === "/" ? "button" : "a"}
-						type={$page.route.id === "/" ? "button" : undefined}
-						href={$page.route.id === "/" ? undefined : "/"}
+						this={page.route.id === "/" ? "button" : "a"}
+						type={page.route.id === "/" ? "button" : undefined}
+						href={page.route.id === "/" ? undefined : "/"}
 						class="grid origin-left overflow-hidden scale-110 *:col-start-1 *:col-end-1 *:row-start-1 *:row-end-1"
-						onclick={$page.route.id === "/"
+						onclick={page.route.id === "/"
 							? () =>
 									window.scrollTo({
 										top: 0
@@ -181,7 +176,7 @@
 						{#each navbarItems as item}
 							{@const linkClasses =
 								"relative after:absolute after:-bottom-1.5 after:left-0 after:h-1 after:w-0 after:bg-dominant after:duration-300 after:content-[''] hover:after:w-full"}
-							{#if i18n.route(item.href) === $page.route.id}
+							{#if i18n.route(item.href) === page.route.id}
 								<span
 									class="relative text-dominant after:absolute after:-bottom-1.5 after:left-0 after:h-1 after:w-full after:bg-dominant after:content-['']"
 								>
@@ -196,7 +191,7 @@
 									type="button"
 									class={linkClasses}
 									onclick={async () => {
-										if ($page.route.id !== "/") {
+										if (page.route.id !== "/") {
 											await goto("/");
 										}
 										document.querySelector(item.href)?.scrollIntoView();
@@ -270,7 +265,7 @@
 						class="relative after:absolute after:-bottom-1.5 after:left-0 after:h-1 after:w-0 after:bg-dominant after:duration-300 after:content-[''] hover:after:w-full"
 						onclick={() => {
 							onClose.set(async () => {
-								if ($page.route.id !== "/") {
+								if (page.route.id !== "/") {
 									await goto("/");
 								}
 								document.querySelector(item.href)?.scrollIntoView();
@@ -389,7 +384,7 @@
 						<a
 							data-sveltekit-preload-data="off"
 							data-sveltekit-preload-code="hover"
-							href={i18n.resolveRoute($page.route.id ?? "/", lang)}
+							href={i18n.resolveRoute(page.route.id ?? "/", lang)}
 							hreflang={lang}
 							role="radio"
 							aria-current={lang === languageTag() ? "page" : undefined}


### PR DESCRIPTION
Little quality-of-life improvements!
- **ESLint**. Remove spread from config because it's not necessary anymore
- **pnpm**. Upgrade to v10 and hardcode it to avoid incompatibility issues
- **pnpm**. Add `esbuild` in the allowed `postinstall` scripts since that's needed since v10
- **pnpm/SvelteKit**. Upgrade the `"prepare"` script to [run the appropriate script since they removed theirs](https://github.com/sveltejs/kit/releases/tag/%40sveltejs%2Fkit%402.16.0) due to `v10`
	- This should also remove the warnings about missing `.svelte-kit/tsconfig.json` we have during development and builds!
- **pnpm/ESLint**. Properly add `@eslint/js` to the dependencies because indirect dependencies are not working anymore with v10
- **package.json**. Remove dependency-related scripts because they’re objectively not relevant
- **SvelteKit**. Migrate to `$app/state` (automatically migrated with `pnpx sv migrate app-state`)
- **Misc**. Slightly improve code, remove useless dependency, and upgrade Inlang a bit